### PR TITLE
fix: adjustment so that quote currency (second) would always be a sta…

### DIFF
--- a/publisher/go.mod
+++ b/publisher/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/nats-io/nats.go v1.24.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	golang.org/x/crypto v0.12.0
+	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad
 	golang.org/x/sync v0.3.0
 	gorm.io/driver/postgres v1.5.2
 	gorm.io/gorm v1.25.4
@@ -42,7 +43,6 @@ require (
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
-	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad // indirect
 	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect

--- a/publisher/internal/analytics/ethereum/analytics.go
+++ b/publisher/internal/analytics/ethereum/analytics.go
@@ -65,8 +65,8 @@ func init() {
 	burnSig = convertToEventSignature(burnEventHeader)
 	collectSig = convertToEventSignature(collectEventHeader)
 
-	stableCoins = append(stableCoins, strings.ToLower(addressUSDT), strings.ToLower(addressUSDC))
-	nativeCoins = append(nativeCoins, strings.ToLower(addressWETH))
+	stableCoins = []string{strings.ToLower(addressUSDT), strings.ToLower(addressUSDC)}
+	nativeCoins = []string{strings.ToLower(addressWETH)}
 }
 
 func New(ctx context.Context, db repository.Repository, opts ...Option) (*Analytics, error) {

--- a/publisher/internal/analytics/ethereum/analytics.go
+++ b/publisher/internal/analytics/ethereum/analytics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"strings"
 
 	"github.com/SyntropyNet/swapscope/publisher/pkg/analytics"
 	"github.com/SyntropyNet/swapscope/publisher/pkg/repository"
@@ -24,6 +25,9 @@ var (
 	//go:embed Uniswap_Liquidity_Position_contract.json
 	uniswapLiqPositionsABIJson string
 	uniswapLiqPositionsABI     abi.ABI
+
+	stableCoins []string
+	nativeCoins []string
 )
 
 const (
@@ -60,6 +64,9 @@ func init() {
 	transferSig = convertToEventSignature(transferEventHeader)
 	burnSig = convertToEventSignature(burnEventHeader)
 	collectSig = convertToEventSignature(collectEventHeader)
+
+	stableCoins = append(stableCoins, strings.ToLower(addressUSDT), strings.ToLower(addressUSDC))
+	nativeCoins = append(nativeCoins, strings.ToLower(addressWETH))
 }
 
 func New(ctx context.Context, db repository.Repository, opts ...Option) (*Analytics, error) {

--- a/publisher/internal/analytics/ethereum/checks.go
+++ b/publisher/internal/analytics/ethereum/checks.go
@@ -11,25 +11,3 @@ func isUniswapPositionsNFT(address string) bool {
 	}
 	return false
 }
-
-func isStableInvolved(position Position) bool {
-	token0 := position.Token0
-	token1 := position.Token1
-	for _, address := range stableCoins {
-		if strings.EqualFold(token1.Address, address) || strings.EqualFold(token0.Address, address) {
-			return true
-		}
-	}
-	return false
-}
-
-func isNativeInvolved(position Position) bool {
-	token0 := position.Token0
-	token1 := position.Token1
-	for _, address := range nativeCoins {
-		if strings.EqualFold(token1.Address, address) || strings.EqualFold(token0.Address, address) {
-			return true
-		}
-	}
-	return false
-}

--- a/publisher/internal/analytics/ethereum/checks.go
+++ b/publisher/internal/analytics/ethereum/checks.go
@@ -12,10 +12,21 @@ func isUniswapPositionsNFT(address string) bool {
 	return false
 }
 
-func isStableOrNativeInvolved(position Position) bool {
+func isStableInvolved(position Position) bool {
 	token0 := position.Token0
 	token1 := position.Token1
-	for _, address := range []string{addressWETH, addressUSDC, addressUSDT} {
+	for _, address := range stableCoins {
+		if strings.EqualFold(token1.Address, address) || strings.EqualFold(token0.Address, address) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNativeInvolved(position Position) bool {
+	token0 := position.Token0
+	token1 := position.Token1
+	for _, address := range nativeCoins {
 		if strings.EqualFold(token1.Address, address) || strings.EqualFold(token0.Address, address) {
 			return true
 		}

--- a/publisher/internal/analytics/ethereum/ethereum_test.go
+++ b/publisher/internal/analytics/ethereum/ethereum_test.go
@@ -185,7 +185,7 @@ func Test_isToken1Native(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			res := test.input.isToken1Native()
+			res := test.input.isToken1OneOf(nativeCoins)
 			if res != test.trueRes {
 				t.Errorf("isToken1Native(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
 			}
@@ -210,7 +210,7 @@ func Test_isToken1Stable(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			res := test.input.isToken1Stable()
+			res := test.input.isToken1OneOf(stableCoins)
 			if res != test.trueRes {
 				t.Errorf("isToken1Stable(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
 			}
@@ -231,7 +231,7 @@ func Test_isNativeInvolved(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			res := isNativeInvolved(test.input)
+			res := test.input.isAnyTokenOneOf(nativeCoins)
 			if res != test.trueRes {
 				t.Errorf("isNativeInvolved(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
 			}
@@ -252,7 +252,7 @@ func Test_isStableInvolved(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			res := isStableInvolved(test.input)
+			res := test.input.isAnyTokenOneOf(stableCoins)
 			if res != test.trueRes {
 				t.Errorf("isStableInvolved(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
 			}

--- a/publisher/internal/analytics/ethereum/ethereum_test.go
+++ b/publisher/internal/analytics/ethereum/ethereum_test.go
@@ -28,15 +28,15 @@ func Test_tickConversion(t *testing.T) {
 		trueLowerRatio float64
 		trueUpperRatio float64
 	}{
-		{"Custom/native: Ticks > 0, res ratio < 1, low range", &Position{Token0: knownTokens["WBTC"], Token1: knownTokens["WETH"], LowerTick: 259720, UpperTick: 259750}, 0.052452336044, 0.052609921433}, // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/591227
-		{"Custom/native: Ticks > 0, res ratio < 1, big range", &Position{Token0: knownTokens["WBTC"], Token1: knownTokens["WETH"], LowerTick: 258310, UpperTick: 259930}, 0.051516686880, 0.060575933233}, //
-		{"Custom/native: Ticks < 0, low range", &Position{Token0: knownTokens["MATIC"], Token1: knownTokens["WETH"], LowerTick: -79980, UpperTick: -79500}, 2834.4481085213397, 2973.812642817363},        // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/587211
-		{"Custom/native: Ticks < 0, big range", &Position{Token0: knownTokens["MATIC"], Token1: knownTokens["WETH"], LowerTick: -90240, UpperTick: -78420}, 2544.292581085861, 8296.166586725507},         // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/587556
-		{"Stable/native: Ticks > 0, big range", &Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"], LowerTick: 186220, UpperTick: 201460}, 1782.956728761764, 8184.129686609503},          // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593545
-		{"Stable/native: Ticks > 0, big range", &Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"], LowerTick: 201450, UpperTick: 203190}, 1499.724941901797, 1784.7404880350452},         // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593547
-		{"Stable/native: Ticks > 0, low range", &Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"], LowerTick: 201090, UpperTick: 201650}, 1749.4020078533288, 1850.158331324582},         // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593603
-		{"Native/stable: Ticks < 0, big range", &Position{Token0: knownTokens["WETH"], Token1: knownTokens["USDT"], LowerTick: -204660, UpperTick: -197760}, 1294.7130255963305, 2581.2004232087493},      // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593557
-		{"Native/stable: Ticks < 0, low range", &Position{Token0: knownTokens["WETH"], Token1: knownTokens["USDT"], LowerTick: -201480, UpperTick: -201470}, 1779.3945567691965, 1781.1747522670805},      // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593392
+		{"Custom/native: Ticks > 0, res ratio < 1, low range", &Position{Token0: knownTokens["WBTC"], Token1: knownTokens["WETH"], LowerTick: 259720, UpperTick: 259750}, 19.007821581, 19.064927807},   // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/591227
+		{"Custom/native: Ticks > 0, res ratio < 1, big range", &Position{Token0: knownTokens["WBTC"], Token1: knownTokens["WETH"], LowerTick: 258310, UpperTick: 259930}, 16.5082062564, 19.4111861717}, //
+		{"Custom/native: Ticks < 0, low range", &Position{Token0: knownTokens["MATIC"], Token1: knownTokens["WETH"], LowerTick: -79980, UpperTick: -79500}, 0.0003362686625, 0.00035280236635},          // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/587211
+		{"Custom/native: Ticks < 0, big range", &Position{Token0: knownTokens["MATIC"], Token1: knownTokens["WETH"], LowerTick: -90240, UpperTick: -78420}, 0.00012053759884, 0.000393036558},           // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/587556
+		{"Stable/native: Ticks > 0, big range", &Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"], LowerTick: 186220, UpperTick: 201460}, 1782.956728761764, 8184.129686609503},        // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593545
+		{"Stable/native: Ticks > 0, big range", &Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"], LowerTick: 201450, UpperTick: 203190}, 1499.724941901797, 1784.7404880350452},       // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593547
+		{"Stable/native: Ticks > 0, low range", &Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"], LowerTick: 201090, UpperTick: 201650}, 1749.4020078533288, 1850.158331324582},       // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593603
+		{"Native/stable: Ticks < 0, big range", &Position{Token0: knownTokens["WETH"], Token1: knownTokens["USDT"], LowerTick: -204660, UpperTick: -197760}, 1294.7130255963305, 2581.2004232087493},    // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593557
+		{"Native/stable: Ticks < 0, low range", &Position{Token0: knownTokens["WETH"], Token1: knownTokens["USDT"], LowerTick: -201480, UpperTick: -201470}, 1779.3945567691965, 1781.1747522670805},    // https://etherscan.io/nft/0xc36442b4a4522e871399cd717abdd847ab11fe88/593392
 	}
 
 	for _, test := range tests {
@@ -168,7 +168,7 @@ func Test_hasTopics(t *testing.T) {
 	}
 }
 
-func Test_isToken0StableAndToken1Native(t *testing.T) {
+func Test_isToken1Native(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   Position
@@ -180,20 +180,45 @@ func Test_isToken0StableAndToken1Native(t *testing.T) {
 		{"stable/native", Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"]}, true},
 		{"native/stable", Position{Token0: knownTokens["WETH"], Token1: knownTokens["USDC"]}, false},
 		{"native/stable", Position{Token0: knownTokens["WETH"], Token1: knownTokens["USDT"]}, false},
-		{"stable/stable", Position{Token0: knownTokens["USDC"], Token1: knownTokens["USDT"]}, true},
-		{"stable/stable", Position{Token0: knownTokens["USDT"], Token1: knownTokens["USDC"]}, true},
+		{"stable/stable", Position{Token0: knownTokens["USDC"], Token1: knownTokens["USDT"]}, false},
+		{"stable/stable", Position{Token0: knownTokens["USDT"], Token1: knownTokens["USDC"]}, false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			res := test.input.isToken0StableAndToken1Native()
+			res := test.input.isToken1Native()
 			if res != test.trueRes {
-				t.Errorf("isOrderCorrect(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
+				t.Errorf("isToken1Native(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
 			}
 		})
 	}
 }
 
-func Test_isStableOrNativeInvolved(t *testing.T) {
+func Test_isToken1Stable(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   Position
+		trueRes bool
+	}{
+		{"native/custom", Position{Token0: knownTokens["WETH"], Token1: knownTokens["WBTC"]}, false},
+		{"custom/native", Position{Token0: knownTokens["WBTC"], Token1: knownTokens["WETH"]}, false},
+		{"custom/native", Position{Token0: knownTokens["MATIC"], Token1: knownTokens["WETH"]}, false},
+		{"stable/native", Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"]}, false},
+		{"native/stable", Position{Token0: knownTokens["WETH"], Token1: knownTokens["USDC"]}, true},
+		{"native/stable", Position{Token0: knownTokens["WETH"], Token1: knownTokens["USDT"]}, true},
+		{"stable/stable", Position{Token0: knownTokens["USDC"], Token1: knownTokens["USDT"]}, true},
+		{"stable/stable", Position{Token0: knownTokens["USDT"], Token1: knownTokens["USDC"]}, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := test.input.isToken1Stable()
+			if res != test.trueRes {
+				t.Errorf("isToken1Stable(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
+			}
+		})
+	}
+}
+
+func Test_isNativeInvolved(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   Position
@@ -202,13 +227,34 @@ func Test_isStableOrNativeInvolved(t *testing.T) {
 		{"custom/native", Position{Token0: knownTokens["WBTC"], Token1: knownTokens["WETH"]}, true},
 		{"stable/native", Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"]}, true},
 		{"custom/custom", Position{Token0: knownTokens["WBTC"], Token1: knownTokens["PEPE"]}, false},
+		{"stable/custom", Position{Token0: knownTokens["USDC"], Token1: knownTokens["PEPE"]}, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := isNativeInvolved(test.input)
+			if res != test.trueRes {
+				t.Errorf("isNativeInvolved(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
+			}
+		})
+	}
+}
+
+func Test_isStableInvolved(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   Position
+		trueRes bool
+	}{
+		{"custom/native", Position{Token0: knownTokens["WBTC"], Token1: knownTokens["WETH"]}, false},
+		{"stable/native", Position{Token0: knownTokens["USDC"], Token1: knownTokens["WETH"]}, true},
+		{"custom/custom", Position{Token0: knownTokens["WBTC"], Token1: knownTokens["PEPE"]}, false},
 		{"stable/custom", Position{Token0: knownTokens["USDC"], Token1: knownTokens["PEPE"]}, true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			res := isStableOrNativeInvolved(test.input)
+			res := isStableInvolved(test.input)
 			if res != test.trueRes {
-				t.Errorf("isStableOrNativeInvolved(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
+				t.Errorf("isStableInvolved(%v) = (%v); expected (%v)", test.input, res, test.trueRes)
 			}
 		})
 	}

--- a/publisher/internal/analytics/ethereum/operations.go
+++ b/publisher/internal/analytics/ethereum/operations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SyntropyNet/swapscope/publisher/pkg/analytics"
 	"github.com/SyntropyNet/swapscope/publisher/pkg/repository"
 	"github.com/SyntropyNet/swapscope/publisher/pkg/types"
+	"golang.org/x/exp/slices"
 )
 
 type Fetchers struct {
@@ -152,11 +153,13 @@ func (rem *Removal) Process(collect WrappedEventLog) error {
 	rem.Position = *remPosition
 	rem.Token0.Price = rem.fetchTokenPrice(rem.Token0.Address)
 	rem.Token1.Price = rem.fetchTokenPrice(rem.Token1.Address)
-	err = rem.calculateFeesEarned(collect.Log)
+
+	rem.Position.calculate()
+
+	err = rem.calculateFeesEarned(collect.Log, addr0, addr1)
 	if err != nil {
 		return err
 	}
-	rem.Position.calculate()
 	return nil
 }
 
@@ -322,19 +325,21 @@ func (add *Addition) handleLiquidityTransfer(mint EventLog, transfer EventLog) {
 	}
 }
 
-func (rem *Removal) calculateFeesEarned(collectLog EventLog) error {
+func (rem *Removal) calculateFeesEarned(collectLog EventLog, poolOrderToken0 string, poolOrderToken1 string) error {
 	token0HexAmount, token1HexAmount, err := convertLogDataToHexAmounts(collectLog.Data, collectEvent) // Token order original as in liquidity pool
 	if err != nil {
 		return err
 	}
 
 	rem.Token0Earned, rem.Token1Earned = rem.Token0, rem.Token1
+
+	if strings.EqualFold(rem.Token0.Address, poolOrderToken1) && strings.EqualFold(rem.Token1.Address, poolOrderToken0) {
+		rem.Token0Earned, rem.Token1Earned = rem.Token1Earned, rem.Token0Earned // Removed tokens were switched during processing - switch earned tokens as well
+		token0HexAmount, token1HexAmount = token1HexAmount, token0HexAmount
+	}
+
 	rem.Token0Earned.Amount = convertTransferAmount(token0HexAmount, rem.Token0.Decimals) - rem.Token0.Amount
 	rem.Token1Earned.Amount = convertTransferAmount(token1HexAmount, rem.Token1.Decimals) - rem.Token1.Amount
-
-	if !rem.Position.isToken0StableAndToken1Native() {
-		rem.Token0Earned, rem.Token1Earned = rem.Token1Earned, rem.Token0Earned
-	}
 
 	return nil
 }
@@ -370,11 +375,12 @@ func (pos *Position) calculateRatios() {
 	lowerRatio := convertTickToRatio(pos.LowerTick, pos.Token0.Decimals, pos.Token1.Decimals)
 	upperRatio := convertTickToRatio(pos.UpperTick, pos.Token0.Decimals, pos.Token1.Decimals)
 
-	if isStableOrNativeInvolved(*pos) && pos.isToken0StableAndToken1Native() {
+	if (isStableInvolved(*pos) && isNativeInvolved(*pos) && !pos.isToken1Stable()) || // USDC/T + WETH, case: WETH/USDT
+		(!isStableInvolved(*pos) && isNativeInvolved(*pos) && !pos.isToken1Native()) || // ANY + WETH, case: WETH/ANY
+		(isStableInvolved(*pos) && !isNativeInvolved(*pos) && !pos.isToken1Stable()) { // ANY + USDC/T, case: USD_/ANY
 		lowerRatio = 1 / lowerRatio
 		upperRatio = 1 / upperRatio
 	}
-
 	if lowerRatio > upperRatio {
 		lowerRatio, upperRatio = upperRatio, lowerRatio
 	}
@@ -390,13 +396,14 @@ func (pos *Position) calculate() {
 	pos.adjustOrder()
 
 	if pos.Token0.Price > 0 && pos.Token1.Price > 0 {
-		pos.CurrentRatio = pos.Token1.Price / pos.Token0.Price
+		pos.CurrentRatio = pos.Token0.Price / pos.Token1.Price
 	}
 	pos.TotalValue = pos.Token1.Price*pos.Token1.Amount + pos.Token0.Price*pos.Token0.Amount
 }
 
 func (pos *Position) adjustOrder() {
-	if isStableOrNativeInvolved(*pos) && !pos.isToken0StableAndToken1Native() {
+	if (isNativeInvolved(*pos) && !isStableInvolved(*pos) && !pos.isToken1Native()) ||
+		(isStableInvolved(*pos) && !pos.isToken1Stable()) {
 		pos.Token1, pos.Token0 = pos.Token0, pos.Token1
 	}
 }
@@ -448,7 +455,10 @@ func (p Position) CanPublish() bool {
 		log.Printf("SKIP - missing price (could not calculate current ratio). Tx: %s\n\n", p.TxHash)
 		return false
 	}
-
+	if !isNativeInvolved(p) && !isStableInvolved(p) {
+		log.Printf("SKIP - no stable or native currency involved. Tx: %s\n\n", p.TxHash)
+		return false
+	}
 	return true
 }
 
@@ -456,8 +466,12 @@ func (p Position) areTokensSet() bool {
 	return (!strings.EqualFold(p.Token0.Address, "") && !strings.EqualFold(p.Token1.Address, ""))
 }
 
-func (p Position) isToken0StableAndToken1Native() bool {
-	return (strings.EqualFold(p.Token1.Address, addressWETH) || strings.EqualFold(p.Token0.Address, addressUSDC) || strings.EqualFold(p.Token0.Address, addressUSDT))
+func (p Position) isToken1Stable() bool {
+	return slices.Contains(stableCoins, strings.ToLower(p.Token1.Address))
+}
+
+func (p Position) isToken1Native() bool {
+	return slices.Contains(nativeCoins, strings.ToLower(p.Token1.Address))
 }
 
 func (p Position) isEitherTokenAmountZero() bool {

--- a/publisher/internal/analytics/ethereum/operations.go
+++ b/publisher/internal/analytics/ethereum/operations.go
@@ -375,9 +375,8 @@ func (pos *Position) calculateRatios() {
 	lowerRatio := convertTickToRatio(pos.LowerTick, pos.Token0.Decimals, pos.Token1.Decimals)
 	upperRatio := convertTickToRatio(pos.UpperTick, pos.Token0.Decimals, pos.Token1.Decimals)
 
-	if (isStableInvolved(*pos) && isNativeInvolved(*pos) && !pos.isToken1Stable()) || // USDC/T + WETH, case: WETH/USDT
-		(!isStableInvolved(*pos) && isNativeInvolved(*pos) && !pos.isToken1Native()) || // ANY + WETH, case: WETH/ANY
-		(isStableInvolved(*pos) && !isNativeInvolved(*pos) && !pos.isToken1Stable()) { // ANY + USDC/T, case: USD_/ANY
+	if (isStableInvolved(*pos) && !pos.isToken1Stable()) || // Stable (USDC, USDT) to always be quote token (second)
+		(!isStableInvolved(*pos) && isNativeInvolved(*pos) && !pos.isToken1Native()) { // If there is no stable token involved - WETH will always be quoto token
 		lowerRatio = 1 / lowerRatio
 		upperRatio = 1 / upperRatio
 	}


### PR DESCRIPTION
See issue description: https://github.com/SyntropyNet/swapscope/issues/37

Quote currency (token) always to be USDC or USDT or (if none of USD* coins are present - WETH).
Quote currency is always second in the pair. Dapp graph Y-axis should always represent quote token (USD* or WETH).
Adjusted position of tokens in pair and ratio calculation where required.